### PR TITLE
fix: update Goerli references to Sepolia

### DIFF
--- a/src/veramo/setup.ts
+++ b/src/veramo/setup.ts
@@ -61,12 +61,12 @@ const KMS_SECRET_KEY =
       }),
       new DIDManager({
         store: new DIDStore(dbConnection),
-        defaultProvider: 'did:ethr:goerli',
+        defaultProvider: 'did:ethr:sepolia',
         providers: {
-          'did:ethr:goerli': new EthrDIDProvider({
+          'did:ethr:sepolia': new EthrDIDProvider({
             defaultKms: 'local',
-            network: 'goerli',
-            rpcUrl: 'https://goerli.infura.io/v3/' + INFURA_PROJECT_ID,
+            network: 'sepolia',
+            rpcUrl: 'https://sepolia.infura.io/v3/' + INFURA_PROJECT_ID,
           }),
           'did:web': new WebDIDProvider({
             defaultKms: 'local',

--- a/src/verify-credential.ts
+++ b/src/verify-credential.ts
@@ -3,25 +3,25 @@ import { agent } from './veramo/setup.js'
 async function main() {
   const result = await agent.verifyCredential({
     credential: {
-      "credentialSubject": {
-        "you": "Rock",
-        "id": "did:web:example.com"
-      },
-      "issuer": {
-        "id": "did:ethr:goerli:0x0350eeeea1410c5b152f1a88e0ffe8bb8a0bc3df868b740eb2352b1dbf93b59c16"
-      },
-      "type": [
-        "VerifiableCredential"
-      ],
-      "@context": [
-        "https://www.w3.org/2018/credentials/v1"
-      ],
-      "issuanceDate": "2022-10-28T11:54:22.000Z",
-      "proof": {
-        "type": "JwtProof2020",
-        "jwt": "eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7InlvdSI6IlJvY2sifX0sInN1YiI6ImRpZDp3ZWI6ZXhhbXBsZS5jb20iLCJuYmYiOjE2NjY5NTgwNjIsImlzcyI6ImRpZDpldGhyOmdvZXJsaToweDAzNTBlZWVlYTE0MTBjNWIxNTJmMWE4OGUwZmZlOGJiOGEwYmMzZGY4NjhiNzQwZWIyMzUyYjFkYmY5M2I1OWMxNiJ9.EPeuQBpkK13V9wu66SLg7u8ebY2OS8b2Biah2Vw-RI-Atui2rtujQkVc2t9m1Eqm4XQFECfysgQBdWwnSDvIjw"
+        "credentialSubject": {
+          "you": "Rock",
+          "id": "did:web:example.com"
+        },
+        "issuer": {
+          "id": "did:ethr:sepolia:0x02bd224258f3b0ae8fa5388342783d9697dac9133eb476c7946eeed9ac7b864ce1"
+        },
+        "type": [
+          "VerifiableCredential"
+        ],
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1"
+        ],
+        "issuanceDate": "2024-06-04T14:37:27.000Z",
+        "proof": {
+          "type": "JwtProof2020",
+          "jwt": "eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7InlvdSI6IlJvY2sifX0sInN1YiI6ImRpZDp3ZWI6ZXhhbXBsZS5jb20iLCJuYmYiOjE3MTc1MTE4NDcsImlzcyI6ImRpZDpldGhyOnNlcG9saWE6MHgwMmJkMjI0MjU4ZjNiMGFlOGZhNTM4ODM0Mjc4M2Q5Njk3ZGFjOTEzM2ViNDc2Yzc5NDZlZWVkOWFjN2I4NjRjZTEifQ.rbpmqCNl8snAH_-rgSgbkj9IPpHIps6tLu1DptmP9JtVkQxj4FpN2y9cvHfDKa5Ekb8qWrgUcyLSOLpk6LO3_Q"
+        }
       }
-    }
   })
   console.log(`Credential verified`, result.verified)
 }


### PR DESCRIPTION
The project was using outdated references to the Goerli testnet, which has been deprecated with the Infura API. This commit updates these references to the Sepolia testnet to ensure the network functionality is not interrupted.